### PR TITLE
Fetch dependency from any repository under OWNER

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -42,7 +42,7 @@ jobs:
             <repositories>
               <repository>
                 <id>github</id>
-                <url>https://maven.pkg.github.com/${{ github.repository_owner }}/maven-publish</url>
+                <url>https://maven.pkg.github.com/${{ github.repository_owner }}/*</url>
               </repository>
             </repositories>
           </project>


### PR DESCRIPTION
We can now use the following, instead of explicitly specifying the repository name!

```
https://maven.pkg.github.com/OWNER/*
```
